### PR TITLE
[ci skip] Remove channels from conda-forge.yml (for conda-smithy 3.28.0)

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,3 @@
-channels:
-  sources:
-    - conda-forge
-  targets:
-    - ["tiledb", "main"]
 github:
   user_or_org: TileDB-Inc
   branch_name: main


### PR DESCRIPTION
Please squash and merge to avoid running CI post-merge (I don't have write access)